### PR TITLE
fix #4 - use ScrapyElasticSearch to store into ES

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,7 +5,7 @@ Requirements
 ------------
 
 * `python`_ 2.7, `virtualenv`_, & `pip`_ for app server
-* `elasticsearch`_
+* `elasticsearch`_ for search index
 
 .. _python: https://www.python.org/
 .. _virtualenv: http://docs.python-guide.org/en/latest/dev/virtualenvs/
@@ -48,8 +48,29 @@ Install Locally
 .. _Create a superuser: https://docs.djangoproject.com/en/1.9/ref/django-admin/#django-admin-createsuperuser
 
 
-Run it
-------
+Run the spider
+--------------
+
+#. Start your `elasticsearch`_ server to store documents
+
+#. Source the ``.env`` file to set environment config vars (Can also use `autoenv`_)::
+
+    source .env
+
+#. Activate the `virtual environment`_ (Can also use `virtualenvwrapper`_)::
+
+    source env/bin/activate
+
+#. Go to the ``scrapy_city`` directory::
+    
+    cd scrapy_city/scrapy_city
+
+#. Run it::
+
+    scrapy runspider spiders/city_spider.py
+
+Run the site
+------------
 
 #. Source the ``.env`` file to set environment config vars (Can also use `autoenv`_)::
 
@@ -101,3 +122,4 @@ We have `Issues`_.
 .. _virtual environment: http://docs.python-guide.org/en/latest/dev/virtualenvs/
 .. _virtualenvwrapper: https://pypi.python.org/pypi/virtualenvwrapper
 .. _autoenv: https://github.com/kennethreitz/autoenv
+.. _elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gunicorn==19.4.5
 python-decouple==3.0
 whitenoise==2.0.6
 scrapy==1.0.5
+ScrapyElasticSearch==0.6.1

--- a/scrapy_city/scrapy_city/settings.py
+++ b/scrapy_city/scrapy_city/settings.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import logging
+
+from decouple import config
 
 # Scrapy settings for scrapy_city project
 #
@@ -61,9 +64,9 @@ NEWSPIDER_MODULE = 'scrapy_city.spiders'
 
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
-#    'scrapy_city.pipelines.SomePipeline': 300,
-#}
+ITEM_PIPELINES = {
+    'scrapyelasticsearch.scrapyelasticsearch.ElasticSearchPipeline': 300,
+}
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html
@@ -83,3 +86,12 @@ NEWSPIDER_MODULE = 'scrapy_city.spiders'
 #HTTPCACHE_DIR='httpcache'
 #HTTPCACHE_IGNORE_HTTP_CODES=[]
 #HTTPCACHE_STORAGE='scrapy.extensions.httpcache.FilesystemCacheStorage'
+
+ELASTICSEARCH_SERVER = config('ELASTICSEARCH_SERVER', 'localhost')
+ELASTICSEARCH_PORT = config('ELASTICSEARCH_PORT', 9200)
+ELASTICSEARCH_USERNAME = config('ELASTICSEARCH_USERNAME', '')
+ELASTICSEARCH_PASSWORD = config('ELASTICSEARCH_PASSWORD', '')
+ELASTICSEARCH_INDEX = config('ELASTICSEARCH_INDEX', 'scrapy')
+ELASTICSEARCH_TYPE = config('ELASTICSEARCH_TYPE', 'items')
+ELASTICSEARCH_UNIQ_KEY = config('ELASTICSEARCH_UNIQ_KEY', 'url')
+ELASTICSEARCH_LOG_LEVEL = config('ELASTICSEARCH_LOG_LEVEL', logging.ERROR)


### PR DESCRIPTION
@ttowncompiled - can you spot-check this on your machine too? I added a "Run the spider" section to the docs; when I did it (and installed Marvel Agent for ES), I was able to see 1k documents going into the ES index with 24 minutes of scraping/crawling ...

![city-struggle-es-marvel](https://cloud.githubusercontent.com/assets/71928/13730099/f0285440-e913-11e5-97c5-a52eb8d8c853.png)
